### PR TITLE
Add maps test endpoint and hook up frontend

### DIFF
--- a/backend/routes/googleMaps.js
+++ b/backend/routes/googleMaps.js
@@ -2,6 +2,11 @@ const express = require('express');
 const router = express.Router();
 const axios = require('axios');
 
+// Simple test route to verify the maps endpoint is reachable
+router.get('/', (req, res) => {
+  res.json({ message: 'Maps API test endpoint' });
+});
+
 router.get('/geocode', async (req, res) => {
   try {
     const { address } = req.query;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,8 +4,8 @@ import axios from 'axios';
 function App() {
   const handleExample = async () => {
     try {
-      const res = await axios.get('/api/maps/geocode', { params: { address: 'Seattle' } });
-      console.log(res.data);
+      const res = await axios.get('/api/maps');
+      alert(res.data.message);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- add a simple `/api/maps` endpoint that replies with a test message
- update React app to request this endpoint and display the result

## Testing
- `npm --prefix backend test` *(fails: Missing script)*
- `CI=true npm --prefix frontend test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68563901876c8323b15e70083a33860c