### PR TITLE
Add World Cup Toronto multilingual UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,18 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "axios": "^1.5.1",
+    "@heroicons/react": "^2.2.0",
+    "autoprefixer": "^10.4.21",
+    "axios": "^1.10.0",
+    "i18next": "^25.2.1",
+    "postcss": "^8.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-i18next": "^15.5.3",
+    "react-router-dom": "^7.6.2",
+    "react-scripts": "5.0.1",
+    "styled-components": "^6.1.19",
+    "tailwindcss": "^4.1.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,25 +1,35 @@
 import React from 'react';
-import SearchBar from './components/SearchBar';
-import TravelCard from './components/TravelCard';
-import MapPlaceholder from './components/MapPlaceholder';
+import { Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import HomePage from './pages/HomePage';
+import Attractions from './pages/Attractions';
+import LocalGuides from './pages/LocalGuides';
+import NearbyCities from './pages/NearbyCities';
+import FoodCulture from './pages/FoodCulture';
+import Tips from './pages/Tips';
+import Itinerary from './pages/Itinerary';
+import Essentials from './pages/Essentials';
+import Nightlife from './pages/Nightlife';
+import Monetization from './pages/Monetization';
 
 function App() {
-  const dummyTrips = [
-    { id: 1, title: 'Paris Adventure', description: 'Explore the city of lights' },
-    { id: 2, title: 'New York Getaway', description: 'Experience the big apple' },
-    { id: 3, title: 'Tokyo Discovery', description: 'Dive into Japanese culture' },
-  ];
-
   return (
-    <div style={{ textAlign: 'center', padding: '20px' }}>
-      <h1>Smart Travel Hub</h1>
-      <SearchBar />
-      <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
-        {dummyTrips.map((trip) => (
-          <TravelCard key={trip.id} title={trip.title} description={trip.description} />
-        ))}
+    <div>
+      <Navbar />
+      <div style={{ padding: '20px' }}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/attractions" element={<Attractions />} />
+          <Route path="/guides" element={<LocalGuides />} />
+          <Route path="/nearby" element={<NearbyCities />} />
+          <Route path="/food" element={<FoodCulture />} />
+          <Route path="/tips" element={<Tips />} />
+          <Route path="/itinerary" element={<Itinerary />} />
+          <Route path="/essentials" element={<Essentials />} />
+          <Route path="/nightlife" element={<Nightlife />} />
+          <Route path="/monetization" element={<Monetization />} />
+        </Routes>
       </div>
-      <MapPlaceholder />
     </div>
   );
 }

--- a/frontend/src/components/LanguageSelector.jsx
+++ b/frontend/src/components/LanguageSelector.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+function LanguageSelector() {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = (e) => {
+    i18n.changeLanguage(e.target.value);
+  };
+
+  return (
+    <select onChange={changeLanguage} value={i18n.language} style={{ marginLeft: '10px' }}>
+      <option value="en">English</option>
+      <option value="es">Español</option>
+      <option value="fr">Français</option>
+      <option value="ar">العربية</option>
+      <option value="zh">中文</option>
+      <option value="pt">Português</option>
+    </select>
+  );
+}
+
+export default LanguageSelector;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import LanguageSelector from './LanguageSelector';
+
+function Navbar() {
+  const { t } = useTranslation();
+  return (
+    <nav style={{ display: 'flex', gap: '10px', padding: '10px', borderBottom: '1px solid #ccc' }}>
+      <Link to="/">{t('nav.home')}</Link>
+      <Link to="/attractions">{t('nav.attractions')}</Link>
+      <Link to="/guides">{t('nav.guides')}</Link>
+      <Link to="/nearby">{t('nav.nearby')}</Link>
+      <Link to="/food">{t('nav.food')}</Link>
+      <Link to="/tips">{t('nav.tips')}</Link>
+      <Link to="/itinerary">{t('nav.itinerary')}</Link>
+      <Link to="/essentials">{t('nav.essentials')}</Link>
+      <Link to="/nightlife">{t('nav.nightlife')}</Link>
+      <Link to="/monetization">{t('nav.monetization')}</Link>
+      <LanguageSelector />
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,28 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en/translation.json';
+import es from './locales/es/translation.json';
+import fr from './locales/fr/translation.json';
+import ar from './locales/ar/translation.json';
+import zh from './locales/zh/translation.json';
+import pt from './locales/pt/translation.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      es: { translation: es },
+      fr: { translation: fr },
+      ar: { translation: ar },
+      zh: { translation: zh },
+      pt: { translation: pt },
+    },
+    lng: navigator.language.split('-')[0],
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 import App from './App';
+import i18n from './i18n';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <I18nextProvider i18n={i18n}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </I18nextProvider>
+);

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -1,0 +1,16 @@
+{
+  "title": "Smart Travel Hub – Toronto",
+  "nav": {
+    "home": "Home",
+    "attractions": "Attractions",
+    "guides": "Local Guides",
+    "nearby": "Nearby Cities",
+    "food": "Food & Culture",
+    "tips": "Tips",
+    "itinerary": "Itinerary",
+    "essentials": "Essentials",
+    "nightlife": "Nightlife",
+    "monetization": "Monetization"
+  },
+  "welcome": "Welcome to the Toronto City Explorer for the 2026 World Cup!"
+}

--- a/frontend/src/pages/Attractions.jsx
+++ b/frontend/src/pages/Attractions.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+function Attractions() {
+  const attractions = [
+    { id: 1, title: 'CN Tower', description: 'Iconic tower', link: '#' },
+    { id: 2, title: 'Royal Ontario Museum', description: 'Museum exhibits', link: '#' },
+    { id: 3, title: 'Toronto Islands', description: 'Island parks', link: '#' },
+    { id: 4, title: 'Casa Loma', description: 'Gothic Revival castle', link: '#' },
+    { id: 5, title: 'Ripley\'s Aquarium', description: 'Aquarium fun', link: '#' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+      {attractions.map((a) => (
+        <div key={a.id} style={{ border: '1px solid #ccc', padding: '10px', width: '180px' }}>
+          <img src={`https://via.placeholder.com/160x90?text=${encodeURIComponent(a.title)}`} alt={a.title} />
+          <h3>{a.title}</h3>
+          <p>{a.description}</p>
+          <a href={a.link} target="_blank" rel="noopener noreferrer">Book Now</a>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default Attractions;

--- a/frontend/src/pages/Essentials.jsx
+++ b/frontend/src/pages/Essentials.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+function Essentials() {
+  const items = [
+    { id: 1, need: 'SIM', location: 'Airalo' },
+    { id: 2, need: 'Toiletries', location: 'Walmart' },
+    { id: 3, need: 'Transit Card', location: 'Shoppers Drug Mart' },
+  ];
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.need} - {item.location}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default Essentials;

--- a/frontend/src/pages/FoodCulture.jsx
+++ b/frontend/src/pages/FoodCulture.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+function FoodCulture() {
+  const foods = [
+    { id: 1, type: 'Canadian', restaurant: 'Maple Diner', booking: 'OpenTable' },
+    { id: 2, type: 'Chinese', restaurant: 'Dragon City', booking: 'Walk-in' },
+    { id: 3, type: 'Italian', restaurant: 'Pasta House', booking: 'OpenTable' },
+  ];
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          <th>Cuisine</th>
+          <th>Restaurant</th>
+          <th>Booking</th>
+        </tr>
+      </thead>
+      <tbody>
+        {foods.map((f) => (
+          <tr key={f.id}>
+            <td>{f.type}</td>
+            <td>{f.restaurant}</td>
+            <td>{f.booking}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default FoodCulture;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+function HomePage() {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <h2>{t('welcome')}</h2>
+      {/* Weather/Timezone/Stadium info placeholders */}
+      <p>Weather: --</p>
+      <p>Timezone: America/Toronto</p>
+      <p>Stadium: BMO Field</p>
+      {/* Partner logos placeholders */}
+      <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
+        <img src="https://via.placeholder.com/100x50?text=Airalo" alt="Airalo" />
+        <img src="https://via.placeholder.com/100x50?text=VisitorsCoverage" alt="VisitorsCoverage" />
+      </div>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/frontend/src/pages/Itinerary.jsx
+++ b/frontend/src/pages/Itinerary.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const DayBox = styled.div`
+  padding: 10px;
+  color: white;
+  margin-bottom: 10px;
+`;
+
+function Itinerary() {
+  const days = [
+    { id: 1, color: 'green', label: 'Day 1' },
+    { id: 2, color: 'blue', label: 'Day 2' },
+    { id: 3, color: 'red', label: 'Day 3' },
+  ];
+
+  return (
+    <div>
+      {days.map((d) => (
+        <DayBox key={d.id} style={{ backgroundColor: d.color }}>
+          {d.label} - Activities here <a href="#">Book All</a>
+        </DayBox>
+      ))}
+    </div>
+  );
+}
+
+export default Itinerary;

--- a/frontend/src/pages/LocalGuides.jsx
+++ b/frontend/src/pages/LocalGuides.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+function LocalGuides() {
+  const guides = [
+    { id: 1, name: 'Alice', languages: 'EN/FR', rate: '$50', vehicle: 'Yes' },
+    { id: 2, name: 'Bob', languages: 'EN/ES', rate: '$40', vehicle: 'No' },
+    { id: 3, name: 'Carlos', languages: 'EN/PT', rate: '$45', vehicle: 'Yes' },
+  ];
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Languages</th>
+          <th>Rate</th>
+          <th>Vehicle</th>
+          <th>Booking</th>
+        </tr>
+      </thead>
+      <tbody>
+        {guides.map((g) => (
+          <tr key={g.id}>
+            <td>{g.name}</td>
+            <td>{g.languages}</td>
+            <td>{g.rate}</td>
+            <td>{g.vehicle}</td>
+            <td><button>Book</button></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default LocalGuides;

--- a/frontend/src/pages/Monetization.jsx
+++ b/frontend/src/pages/Monetization.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function Monetization() {
+  return (
+    <div>
+      <h3>Partners</h3>
+      <div style={{ display: 'flex', gap: '10px' }}>
+        <img src="https://via.placeholder.com/100x50?text=AdSense" alt="AdSense" />
+        <img src="https://via.placeholder.com/100x50?text=Directory" alt="Directory" />
+        <img src="https://via.placeholder.com/100x50?text=SmartPass" alt="SmartPass" />
+      </div>
+    </div>
+  );
+}
+
+export default Monetization;

--- a/frontend/src/pages/NearbyCities.jsx
+++ b/frontend/src/pages/NearbyCities.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+function NearbyCities() {
+  const cities = [
+    { id: 1, name: 'Niagara Falls', distance: '130km', highlights: 'Falls', transport: 'Bus' },
+    { id: 2, name: 'Ottawa', distance: '450km', highlights: 'Parliament', transport: 'Train' },
+    { id: 3, name: 'Montreal', distance: '540km', highlights: 'Old Port', transport: 'Train' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', overflowX: 'auto', gap: '10px' }}>
+      {cities.map((c) => (
+        <div key={c.id} style={{ minWidth: '180px', border: '1px solid #ccc', padding: '10px' }}>
+          <h3>{c.name}</h3>
+          <p>{c.distance}</p>
+          <p>{c.highlights}</p>
+          <p>{c.transport}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default NearbyCities;

--- a/frontend/src/pages/Nightlife.jsx
+++ b/frontend/src/pages/Nightlife.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+function Nightlife() {
+  const events = [
+    'Club Night at Venue A',
+    'Concert at Venue B',
+    'Festival at Venue C',
+  ];
+
+  return (
+    <ul>
+      {events.map((e, idx) => (
+        <li key={idx}>{e}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default Nightlife;

--- a/frontend/src/pages/Tips.jsx
+++ b/frontend/src/pages/Tips.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+function Tips() {
+  const tips = [
+    'Use a Presto Card for transit',
+    'Uber is widely available',
+    'Tap water is safe to drink',
+    'Tipping is customary (15-20%)',
+  ];
+
+  return (
+    <ul>
+      {tips.map((tip, index) => (
+        <li key={index}>{tip}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default Tips;


### PR DESCRIPTION
## Summary
- overhaul CRA frontend into a multi‑page city explorer
- add react-router navigation and language selector
- integrate i18next with sample translations
- create placeholder pages for attractions, guides, food, tips, itinerary and more

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685643fdcf6483239d2a8daa6a0963b2