### PR TITLE
Fix Tailwind integration for CRA

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,5 +21,20 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.10"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import App from './App';
 import i18n from './i18n';
+import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./public/index.html"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind and PostCSS configs for CRA
- include Tailwind imports in index.css and index.js
- install `@tailwindcss/postcss` plugin and update package.json
- rename Tailwind config so CRA doesn't inject the old plugin

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6858d0b3d8748323a7807adefabd0b76