### PR TITLE
Replace placeholder images with Unsplash photos

### DIFF
--- a/frontend/src/pages/Attractions.jsx
+++ b/frontend/src/pages/Attractions.jsx
@@ -15,7 +15,7 @@ function Attractions() {
       <Grid>
         {attractions.map((a) => (
           <Card key={a.id}>
-            <img src={`https://via.placeholder.com/160x90?text=${encodeURIComponent(a.title)}`} alt={a.title} />
+          <img src={`https://source.unsplash.com/160x90/?landscape,${encodeURIComponent(a.title)}`} alt={a.title} />
             <h3>{a.title}</h3>
             <p>{a.description}</p>
             <Button as="a" href={a.link} target="_blank" rel="noopener noreferrer">Book Now</Button>

--- a/frontend/src/pages/Essentials.jsx
+++ b/frontend/src/pages/Essentials.jsx
@@ -10,7 +10,7 @@ function Essentials() {
 
   return (
     <Container>
-    <img src="https://via.placeholder.com/800x200?text=Essentials" alt="essentials" />
+    <img src="https://source.unsplash.com/800x200/?landscape" alt="essentials" />
     <ul>
       {items.map((item) => (
         <li key={item.id}>{item.need} - {item.location}</li>

--- a/frontend/src/pages/FoodCulture.jsx
+++ b/frontend/src/pages/FoodCulture.jsx
@@ -10,7 +10,7 @@ function FoodCulture() {
 
   return (
     <Container>
-    <img src="https://via.placeholder.com/800x200?text=Food" alt="Food" />
+    <img src="https://source.unsplash.com/800x200/?destination" alt="Food" />
     <StyledTable>
       <thead>
         <tr>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -6,7 +6,7 @@ function HomePage() {
   const { t } = useTranslation();
   return (
     <Container>
-      <img src="https://via.placeholder.com/800x200?text=Toronto" alt="Toronto" />
+      <img src="https://source.unsplash.com/800x200/?city" alt="Toronto" />
       <h2>{t('welcome')}</h2>
       {/* Weather/Timezone/Stadium info placeholders */}
       <p>Weather: --</p>
@@ -14,8 +14,8 @@ function HomePage() {
       <p>Stadium: BMO Field</p>
       {/* Partner logos placeholders */}
       <Grid style={{ marginTop: '10px' }}>
-        <img src="https://via.placeholder.com/100x50?text=Airalo" alt="Airalo" />
-        <img src="https://via.placeholder.com/100x50?text=VisitorsCoverage" alt="VisitorsCoverage" />
+        <img src="https://source.unsplash.com/100x50/?airport" alt="Airalo" />
+        <img src="https://source.unsplash.com/100x50/?hotel" alt="VisitorsCoverage" />
       </Grid>
     </Container>
   );

--- a/frontend/src/pages/Monetization.jsx
+++ b/frontend/src/pages/Monetization.jsx
@@ -4,12 +4,12 @@ import { Container, Grid } from '../styles/components';
 function Monetization() {
   return (
     <Container>
-      <img src="https://via.placeholder.com/800x200?text=Partners" alt="partners" />
+      <img src="https://source.unsplash.com/800x200/?airport" alt="partners" />
       <h3>Partners</h3>
       <Grid>
-        <img src="https://via.placeholder.com/100x50?text=AdSense" alt="AdSense" />
-        <img src="https://via.placeholder.com/100x50?text=Directory" alt="Directory" />
-        <img src="https://via.placeholder.com/100x50?text=SmartPass" alt="SmartPass" />
+        <img src="https://source.unsplash.com/100x50/?city" alt="AdSense" />
+        <img src="https://source.unsplash.com/100x50/?landscape" alt="Directory" />
+        <img src="https://source.unsplash.com/100x50/?adventure" alt="SmartPass" />
       </Grid>
     </Container>
   );

--- a/frontend/src/pages/NearbyCities.jsx
+++ b/frontend/src/pages/NearbyCities.jsx
@@ -13,7 +13,7 @@ function NearbyCities() {
     <Grid style={{ overflowX: 'auto' }}>
       {cities.map((c) => (
         <Card key={c.id} style={{ minWidth: '180px' }}>
-          <img src={`https://via.placeholder.com/160x90?text=${encodeURIComponent(c.name)}`} alt={c.name} />
+          <img src={`https://source.unsplash.com/160x90/?city,${encodeURIComponent(c.name)}`} alt={c.name} />
           <h3>{c.name}</h3>
           <p>{c.distance}</p>
           <p>{c.highlights}</p>

--- a/frontend/src/pages/Nightlife.jsx
+++ b/frontend/src/pages/Nightlife.jsx
@@ -10,7 +10,7 @@ function Nightlife() {
 
   return (
     <Container>
-    <img src="https://via.placeholder.com/800x200?text=Nightlife" alt="nightlife" />
+    <img src="https://source.unsplash.com/800x200/?adventure" alt="nightlife" />
     <ul>
       {events.map((e, idx) => (
         <li key={idx}>{e}</li>

--- a/frontend/src/pages/Tips.jsx
+++ b/frontend/src/pages/Tips.jsx
@@ -11,7 +11,7 @@ function Tips() {
 
   return (
     <Container>
-    <img src="https://via.placeholder.com/800x200?text=Travel+Tips" alt="tips" />
+    <img src="https://source.unsplash.com/800x200/?destination" alt="tips" />
     <ul>
       {tips.map((tip, index) => (
         <li key={index}>{tip}</li>


### PR DESCRIPTION
## Summary
- swap placeholder images for Unsplash-based photos across the React frontend
- keep layout responsive with existing styled components

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ffabb6c8323802582a83fc5f51f