### PR TITLE
Improve UI and add content

### DIFF
--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -5,21 +5,30 @@ function Map() {
   const ref = useRef(null);
 
   useEffect(() => {
-    const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY`;
-    script.async = true;
-    script.onload = () => {
-      if (window.google) {
+    const initMap = () => {
+      if (window.google && ref.current) {
         new window.google.maps.Map(ref.current, {
           center: { lat: 43.6532, lng: -79.3832 },
           zoom: 11,
         });
       }
     };
-    document.body.appendChild(script);
-    return () => {
-      document.body.removeChild(script);
-    };
+
+    if (window.google && window.google.maps) {
+      initMap();
+      return;
+    }
+
+    const scriptId = 'google-maps-script';
+    let script = document.getElementById(scriptId);
+    if (!script) {
+      script = document.createElement('script');
+      script.id = scriptId;
+      script.src = `https://maps.googleapis.com/maps/api/js?key=29d294eef9e21cc10792af93d19ad1cc`;
+      script.async = true;
+      document.body.appendChild(script);
+    }
+    script.onload = initMap;
   }, []);
 
   return <MapBox ref={ref} />;

--- a/frontend/src/pages/Attractions.jsx
+++ b/frontend/src/pages/Attractions.jsx
@@ -53,6 +53,9 @@ function Attractions() {
           </Card>
         ))}
       </Grid>
+      <p style={{ marginTop: '20px', textAlign: 'center' }}>
+        Ready for adventure? <Button as="a" href="#">Plan your visit</Button>
+      </p>
     </Container>
   );
 }

--- a/frontend/src/pages/Essentials.jsx
+++ b/frontend/src/pages/Essentials.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Grid, Card } from '../styles/components';
+import { Container, Grid, Card, Button } from '../styles/components';
 import Hero from '../components/Hero';
 import { DevicePhoneMobileIcon, TicketIcon, MapIcon } from '@heroicons/react/24/outline';
 
@@ -29,6 +29,9 @@ function Essentials() {
           );
         })}
       </Grid>
+      <p style={{ marginTop: '20px', textAlign: 'center' }}>
+        <Button as="a" href="#">Get these essentials</Button>
+      </p>
     </Container>
   );
 }

--- a/frontend/src/pages/FoodCulture.jsx
+++ b/frontend/src/pages/FoodCulture.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, StyledTable, Th, Td } from '../styles/components';
+import { Container, StyledTable, Th, Td, Button } from '../styles/components';
 import Hero from '../components/Hero';
 
 const foods = [
@@ -55,6 +55,9 @@ function FoodCulture() {
         ))}
       </tbody>
     </StyledTable>
+    <p style={{ marginTop: '20px', textAlign: 'center' }}>
+      Hungry? <Button as="a" href="#">Book a table</Button>
+    </p>
     </Container>
   );
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Container, Grid } from '../styles/components';
+import { Container, Grid, Button } from '../styles/components';
 import styled from 'styled-components';
 import Hero from '../components/Hero';
 import Map from '../components/Map';
+import { CheckCircleIcon, MapIcon, ChatBubbleLeftRightIcon, TicketIcon } from '@heroicons/react/24/solid';
 
 
 const PartnerCard = styled.a`
@@ -16,6 +17,26 @@ const PartnerCard = styled.a`
   text-align: center;
   &:hover {
     transform: translateY(-3px);
+  }
+`;
+
+const TwoColumn = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-top: 20px;
+`;
+
+const Column = styled.div`
+  flex: 1 1 300px;
+`;
+
+const Bullet = styled.li`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  svg {
+    margin-right: 6px;
   }
 `;
 
@@ -46,7 +67,28 @@ function HomePage() {
       <p>Current Weather: {weather ? `${weather}°C` : '--'}</p>
       <p>Local Time: {time.toLocaleString('en-CA', { timeZone: 'America/Toronto', timeStyle: 'short', dateStyle: 'long' })}</p>
       <p>Smart Travel Hub helps you discover attractions, food, nightlife and more around Toronto.</p>
-      <Map />
+
+      <TwoColumn>
+        <Column>
+          <Map />
+        </Column>
+        <Column>
+          <h3>Why Choose Toronto?</h3>
+          <ul>
+            <Bullet><CheckCircleIcon width={20} />Diverse attractions for every traveler</Bullet>
+            <Bullet><CheckCircleIcon width={20} />Vibrant multicultural food scene</Bullet>
+            <Bullet><CheckCircleIcon width={20} />Easy access from major cities</Bullet>
+          </ul>
+
+          <h3 style={{ marginTop: '20px' }}>Explore Services</h3>
+          <ul>
+            <Bullet><MapIcon width={20} />Custom itineraries</Bullet>
+            <Bullet><ChatBubbleLeftRightIcon width={20} />Local guides</Bullet>
+            <Bullet><TicketIcon width={20} />Event booking</Bullet>
+          </ul>
+        </Column>
+      </TwoColumn>
+
       <Grid style={{ marginTop: '20px' }}>
         <PartnerCard href="https://www.airalo.com" target="_blank" rel="noreferrer">
           <img src="https://images.unsplash.com/photo-1485217988980-11786ced9454?auto=format&fit=crop&w=200&q=60" alt="Airalo" />

--- a/frontend/src/pages/Itinerary.jsx
+++ b/frontend/src/pages/Itinerary.jsx
@@ -49,6 +49,9 @@ function Itinerary() {
           </div>
         </DayBox>
       ))}
+      <p style={{ textAlign: 'center' }}>
+        <Button as="a" href="#">Save itinerary</Button>
+      </p>
     </Container>
   );
 }

--- a/frontend/src/pages/LocalGuides.jsx
+++ b/frontend/src/pages/LocalGuides.jsx
@@ -75,6 +75,9 @@ function LocalGuides() {
         ))}
       </tbody>
     </StyledTable>
+    <p style={{ textAlign: 'center', marginTop: '20px' }}>
+      <Button as="a" href="#">Contact a guide</Button>
+    </p>
     </Container>
   );
 }

--- a/frontend/src/pages/Monetization.jsx
+++ b/frontend/src/pages/Monetization.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Grid, Card } from '../styles/components';
+import { Container, Grid, Card, Button } from '../styles/components';
 import Hero from '../components/Hero';
 
 function Monetization() {
@@ -41,6 +41,9 @@ function Monetization() {
           </Card>
         ))}
       </Grid>
+      <p style={{ textAlign: 'center', marginTop: '20px' }}>
+        <Button as="a" href="#">Partner with us</Button>
+      </p>
     </Container>
   );
 }

--- a/frontend/src/pages/NearbyCities.jsx
+++ b/frontend/src/pages/NearbyCities.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Grid, Card } from '../styles/components';
+import { Container, Grid, Card, Button } from '../styles/components';
 import Hero from '../components/Hero';
 
 function NearbyCities() {
@@ -27,6 +27,9 @@ function NearbyCities() {
         </Card>
       ))}
     </Grid>
+    <p style={{ textAlign: 'center', marginTop: '20px' }}>
+      <Button as="a" href="#">See transportation options</Button>
+    </p>
     </Container>
   );
 }

--- a/frontend/src/pages/Nightlife.jsx
+++ b/frontend/src/pages/Nightlife.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Grid, Card } from '../styles/components';
+import { Container, Grid, Card, Button } from '../styles/components';
 import Hero from '../components/Hero';
 import { MusicalNoteIcon } from '@heroicons/react/24/outline';
 
@@ -27,6 +27,9 @@ function Nightlife() {
           </Card>
         ))}
       </Grid>
+      <p style={{ textAlign: 'center', marginTop: '20px' }}>
+        <Button as="a" href="#">See all events</Button>
+      </p>
     </Container>
   );
 }

--- a/frontend/src/pages/Tips.jsx
+++ b/frontend/src/pages/Tips.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container } from '../styles/components';
+import { Container, Button } from '../styles/components';
 import Hero from '../components/Hero';
 
 function Tips() {
@@ -22,6 +22,9 @@ function Tips() {
         <li key={index}>{tip}</li>
       ))}
     </ul>
+    <p style={{ textAlign: 'center', marginTop: '20px' }}>
+      <Button as="a" href="#">Share your tips</Button>
+    </p>
     </Container>
   );
 }

--- a/frontend/src/styles/GlobalStyle.js
+++ b/frontend/src/styles/GlobalStyle.js
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import COLORS from './colors';
 
 const GlobalStyle = createGlobalStyle`
   * {
@@ -10,15 +11,15 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     line-height: 1.6;
-    background-color: #f4f6f9;
-    color: #333;
+    background-color: ${COLORS.lightBg};
+    color: ${COLORS.text};
   }
   img {
     max-width: 100%;
     display: block;
   }
   a {
-    color: #007bff;
+    color: ${COLORS.secondary};
     text-decoration: none;
   }
 `;

--- a/frontend/src/styles/colors.js
+++ b/frontend/src/styles/colors.js
@@ -1,0 +1,8 @@
+export const COLORS = {
+  primary: '#2C3E50',
+  secondary: '#3498DB',
+  accent: '#F39C12',
+  lightBg: '#F8F9FA',
+  text: '#333333',
+};
+export default COLORS;

--- a/frontend/src/styles/components.js
+++ b/frontend/src/styles/components.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import COLORS from './colors';
 
 export const Container = styled.div`
   max-width: 960px;
@@ -33,8 +34,8 @@ export const HeroContent = styled.div`
 `;
 
 export const NavbarWrapper = styled.nav`
-  background-color: #fff;
-  border-bottom: 1px solid #ddd;
+  background-color: ${COLORS.primary};
+  border-bottom: 1px solid ${COLORS.secondary};
   padding: 15px 30px;
   display: flex;
   flex-wrap: wrap;
@@ -45,10 +46,10 @@ export const NavbarWrapper = styled.nav`
 export const NavItem = styled(Link)`
   margin-right: 20px;
   font-weight: 500;
-  color: #007bff;
+  color: ${COLORS.lightBg};
   text-decoration: none;
   &:hover {
-    text-decoration: underline;
+    color: ${COLORS.accent};
   }
 `;
 
@@ -69,7 +70,7 @@ export const Card = styled.div`
 
 export const Button = styled.button`
   padding: 0.5rem 1rem;
-  background-color: #007bff;
+  background-color: ${COLORS.accent};
   color: #fff;
   border: none;
   border-radius: 4px;
@@ -91,7 +92,7 @@ export const MapBox = styled.div`
   margin-top: 20px;
   height: 300px;
   border-radius: 10px;
-  border: 1px solid #ccc;
+  border: 1px solid ${COLORS.secondary};
   overflow: hidden;
 `;
 
@@ -101,18 +102,18 @@ export const StyledTable = styled.table`
   font-size: 0.9rem;
 
   tbody tr:nth-child(odd) {
-    background-color: #f6f8fa;
+    background-color: ${COLORS.lightBg};
   }
 `;
 
 export const Th = styled.th`
-  border: 1px solid #ccc;
+  border: 1px solid ${COLORS.secondary};
   padding: 0.5rem;
   text-align: left;
 `;
 
 export const Td = styled.td`
-  border: 1px solid #ccc;
+  border: 1px solid ${COLORS.secondary};
   padding: 0.5rem;
 `;
 
@@ -120,5 +121,5 @@ export const Select = styled.select`
   margin-left: 10px;
   padding: 6px;
   border-radius: 5px;
-  border: 1px solid #ccc;
+  border: 1px solid ${COLORS.secondary};
 `;


### PR DESCRIPTION
## Summary
- implement consistent color palette
- fix Google Maps integration with API key
- expand Home page with sections and icons
- add short calls to action across pages

## Testing
- `npm --prefix frontend test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68601239c0fc8323a2eeee9ba147f1e3