### PR TITLE
Enhance World Cup page layout and features

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "autoprefixer": "^10.4.21",
         "axios": "^1.10.0",
+        "dayjs": "^1.11.13",
         "i18next": "^25.2.1",
         "postcss": "^8.5.6",
         "react": "^18.2.0",
@@ -5913,6 +5914,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,21 +2,21 @@
   "name": "smart-travel-hub-frontend",
   "version": "1.0.0",
   "private": true,
- "dependencies": {
-  "@heroicons/react": "^2.2.0",
-  "autoprefixer": "^10.4.21",
-  "axios": "^1.10.0",
-  "i18next": "^25.2.1",
-  "postcss": "^8.5.6",
-  "react": "^18.2.0",
-  "react-dom": "^18.2.0",
-  "react-i18next": "^15.5.3",
-  "react-router-dom": "^7.6.2",
-  "react-scripts": "5.0.1",
-  "styled-components": "^6.1.19",
-  "typescript": "4.9.5"
-}
-,
+  "dependencies": {
+    "@heroicons/react": "^2.2.0",
+    "autoprefixer": "^10.4.21",
+    "axios": "^1.10.0",
+    "dayjs": "^1.11.13",
+    "i18next": "^25.2.1",
+    "postcss": "^8.5.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-i18next": "^15.5.3",
+    "react-router-dom": "^7.6.2",
+    "react-scripts": "5.0.1",
+    "styled-components": "^6.1.19",
+    "typescript": "4.9.5"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
@@ -34,6 +34,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {}
+  }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import HomePage from './pages/HomePage';
@@ -15,9 +15,15 @@ import WorldCup from './pages/WorldCup';
 import { Container } from './styles/components';
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
   return (
     <div>
-      <Navbar />
+      <Navbar darkMode={darkMode} toggleDark={() => setDarkMode(!darkMode)} />
       <Container>
         <Routes>
           <Route path="/" element={<HomePage />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { NavItem, NavbarWrapper } from '../styles/components';
+import { NavItem, NavbarWrapper, ToggleButton } from '../styles/components';
 import { useTranslation } from 'react-i18next';
 import LanguageSelector from './LanguageSelector';
 
-function Navbar() {
+function Navbar({ darkMode, toggleDark }) {
   const { t } = useTranslation();
   return (
     <NavbarWrapper>
@@ -19,6 +19,7 @@ function Navbar() {
       <NavItem to="/monetization">{t('nav.monetization')}</NavItem>
       <NavItem to="/worldcup">{t('nav.worldcup')}</NavItem>
       <LanguageSelector />
+      <ToggleButton onClick={toggleDark}>{darkMode ? 'Light' : 'Dark'}</ToggleButton>
     </NavbarWrapper>
   );
 }

--- a/frontend/src/pages/WorldCup.jsx
+++ b/frontend/src/pages/WorldCup.jsx
@@ -1,6 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { Container, Grid, Card, StyledTable, Th, Td } from '../styles/components';
+import dayjs from 'dayjs';
+import {
+  Container,
+  Grid,
+  Card,
+  StyledTable,
+  Th,
+  Td,
+  Section,
+  Ticker,
+  NewsGrid,
+  NewsCard,
+  Spinner,
+} from '../styles/components';
 import Hero from '../components/Hero';
 
 function WorldCup() {
@@ -11,6 +24,7 @@ function WorldCup() {
   const [upcomingMatches, setUpcomingMatches] = useState([]);
   const [pastMatches, setPastMatches] = useState([]);
   const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const API_KEY = 'YOUR_API_KEY'; // Insert your API-Football key
   const API_BASE = 'https://v3.football.api-sports.io';
@@ -53,8 +67,29 @@ function WorldCup() {
     },
   ];
 
-  const formatDate = (d) => new Date(d).toLocaleDateString();
-  const formatTime = (d) => new Date(d).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const fallbackNews = [
+    {
+      title: 'Host cities confirmed for Club World Cup',
+      image: 'https://via.placeholder.com/300x140',
+      snippet: 'FIFA announces the stadiums that will stage the upcoming tournament.',
+      link: '#',
+    },
+    {
+      title: 'Star players to watch this year',
+      image: 'https://via.placeholder.com/300x140',
+      snippet: 'A look at the key talents expected to shine on the big stage.',
+      link: '#',
+    },
+    {
+      title: 'How the teams qualified',
+      image: 'https://via.placeholder.com/300x140',
+      snippet: 'Reviewing the path clubs took to earn their place in the competition.',
+      link: '#',
+    },
+  ];
+
+  const formatDate = (d) => dayjs(d).format('MMM D, YYYY');
+  const formatTime = (d) => dayjs(d).format('HH:mm');
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -65,6 +100,7 @@ function WorldCup() {
 
   useEffect(() => {
     const fetchData = async () => {
+      setLoading(true);
       try {
         const standingsRes = await axios.get(`${API_BASE}/standings`, {
           params: { league: LEAGUE_ID, season: SEASON },
@@ -109,6 +145,8 @@ function WorldCup() {
         setStandings(fallbackStandings);
         setUpcomingMatches(fallbackUpcoming);
         setPastMatches(fallbackPast);
+      } finally {
+        setLoading(false);
       }
     };
     fetchData();
@@ -116,84 +154,124 @@ function WorldCup() {
 
   return (
     <Container>
-      <Hero
-        title="FIFA Club World Cup"
-        subtitle="Live Updates"
-        background="https://img.fifa.com/image/upload/fifa-world-cup.jpg"
-      />
-      <h2 style={{ textAlign: 'center', margin: '20px 0' }}>{daysLeft} days left until the FIFA World Cup Final</h2>
-
-      <h3>Group Standings</h3>
-      <Grid>
-        {standings.map((g) => (
-          <Card key={g.group} style={{ minWidth: '250px' }}>
-            <h4>{g.group}</h4>
-            <StyledTable>
-              <thead>
-                <tr>
-                  <Th>Team</Th>
-                  <Th>Pts</Th>
-                  <Th>W</Th>
-                  <Th>L</Th>
-                  <Th>D</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {g.teams.map((t) => (
-                  <tr key={t.name}>
-                    <Td>
-                      <img src={t.logo} alt={t.name} width="20" style={{ marginRight: '4px' }} />
-                      {t.name}
-                    </Td>
-                    <Td>{t.points}</Td>
-                    <Td>{t.wins}</Td>
-                    <Td>{t.losses}</Td>
-                    <Td>{t.draws}</Td>
-                  </tr>
-                ))}
-              </tbody>
-            </StyledTable>
-          </Card>
-        ))}
-      </Grid>
-
-      <h3 style={{ marginTop: '20px' }}>Upcoming Matches</h3>
-      <Grid>
+      <Ticker>
         {upcomingMatches.map((m, idx) => (
-          <Card key={idx} style={{ minWidth: '250px' }}>
-            <h4>
-              <img src={m.logo1} alt={m.team1} width="20" style={{ marginRight: '4px' }} />
-              {m.team1} vs {m.team2}
-              <img src={m.logo2} alt={m.team2} width="20" style={{ marginLeft: '4px' }} />
-            </h4>
-            <p>
-              {formatDate(m.date)} {formatTime(m.date)}
-            </p>
-            <p>
-              {m.stadium}, {m.city}
-            </p>
-          </Card>
+          <span key={idx} style={{ padding: '0 15px' }}>
+            {dayjs(m.date).format('MMM D')} {m.team1} vs {m.team2}
+          </span>
         ))}
-      </Grid>
+      </Ticker>
 
-      <h3 style={{ marginTop: '20px' }}>Past Results</h3>
-      <Grid>
-        {pastMatches.map((m, idx) => (
-          <Card key={idx} style={{ minWidth: '250px' }}>
-            <h4>
-              <img src={m.logo1} alt={m.team1} width="20" style={{ marginRight: '4px' }} />
-              {m.team1} {m.score1} - {m.score2} {m.team2}
-              <img src={m.logo2} alt={m.team2} width="20" style={{ marginLeft: '4px' }} />
-            </h4>
-            <p>
-              {formatDate(m.date)} {formatTime(m.date)}
-            </p>
-            <p>
-              {m.stadium}, {m.city}
-            </p>
-          </Card>
-        ))}
-      </Grid>
+      <Hero
+        title="FIFA Club World Cup | Live Scores & Highlights"
+        background="https://digitalhub.fifa.com/transform/87954546-0b34-4b94-a39f-dbc88fa7bdff"
+      />
+
+      <Section style={{ textAlign: 'center' }}>
+        <h2>{daysLeft} days until the FIFA World Cup Final</h2>
+      </Section>
+
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', margin: '40px 0' }}>
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <Section>
+            <h3>🏟️ Club World Cup Headlines</h3>
+            <NewsGrid>
+              {fallbackNews.map((n, i) => (
+                <NewsCard key={i}>
+                  <img src={n.image} alt={n.title} />
+                  <div>
+                    <h4>{n.title}</h4>
+                    <p>{n.snippet}</p>
+                    <a href={n.link}>Read More</a>
+                  </div>
+                </NewsCard>
+              ))}
+            </NewsGrid>
+          </Section>
+
+          <Section>
+            <h3>Group Standings</h3>
+            <Grid>
+              {standings.map((g) => (
+                <Card as="details" key={g.group} style={{ minWidth: '250px' }}>
+                  <summary>{g.group}</summary>
+                  <StyledTable>
+                    <thead>
+                      <tr>
+                        <Th>Team</Th>
+                        <Th>Pts</Th>
+                        <Th>W</Th>
+                        <Th>L</Th>
+                        <Th>D</Th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {g.teams.map((t) => (
+                        <tr key={t.name}>
+                          <Td>
+                            <img src={t.logo} alt={t.name} width="20" style={{ marginRight: '4px' }} />
+                            {t.name}
+                          </Td>
+                          <Td>{t.points}</Td>
+                          <Td>{t.wins}</Td>
+                          <Td>{t.losses}</Td>
+                          <Td>{t.draws}</Td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </StyledTable>
+                </Card>
+              ))}
+            </Grid>
+          </Section>
+
+          <Section>
+            <h3>Upcoming Matches</h3>
+            <Grid>
+              {upcomingMatches.map((m, idx) => (
+                <Card key={idx} style={{ minWidth: '250px' }}>
+                  <h4>
+                    <img src={m.logo1} alt={m.team1} width="20" style={{ marginRight: '4px' }} />
+                    {m.team1} vs {m.team2}
+                    <img src={m.logo2} alt={m.team2} width="20" style={{ marginLeft: '4px' }} />
+                  </h4>
+                  <p>
+                    {formatDate(m.date)} {formatTime(m.date)}
+                  </p>
+                  <p>
+                    {m.stadium}, {m.city}
+                  </p>
+                </Card>
+              ))}
+            </Grid>
+          </Section>
+
+          <Section>
+            <h3>Past Results</h3>
+            <Grid>
+              {pastMatches.map((m, idx) => (
+                <Card key={idx} style={{ minWidth: '250px' }}>
+                  <h4>
+                    <img src={m.logo1} alt={m.team1} width="20" style={{ marginRight: '4px' }} />
+                    {m.team1} {m.score1} - {m.score2} {m.team2}
+                    <img src={m.logo2} alt={m.team2} width="20" style={{ marginLeft: '4px' }} />
+                  </h4>
+                  <p>
+                    {formatDate(m.date)} {formatTime(m.date)}
+                  </p>
+                  <p>
+                    {m.stadium}, {m.city}
+                  </p>
+                </Card>
+              ))}
+            </Grid>
+          </Section>
+        </>
+      )}
 
       {error && <p style={{ marginTop: '20px' }}>Live data could not be loaded.</p>}
     </Container>

--- a/frontend/src/styles/GlobalStyle.js
+++ b/frontend/src/styles/GlobalStyle.js
@@ -2,6 +2,8 @@ import { createGlobalStyle } from 'styled-components';
 import COLORS from './colors';
 
 const GlobalStyle = createGlobalStyle`
+  @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+
   * {
     box-sizing: border-box;
     margin: 0;
@@ -9,10 +11,17 @@ const GlobalStyle = createGlobalStyle`
   }
   body {
     margin: 0;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Poppins', sans-serif;
     line-height: 1.6;
     background-color: ${COLORS.lightBg};
     color: ${COLORS.text};
+  }
+  body.dark {
+    background-color: ${COLORS.primary};
+    color: #fff;
+  }
+  body.dark a {
+    color: ${COLORS.accent};
   }
   img {
     max-width: 100%;

--- a/frontend/src/styles/components.js
+++ b/frontend/src/styles/components.js
@@ -123,3 +123,62 @@ export const Select = styled.select`
   border-radius: 5px;
   border: 1px solid ${COLORS.secondary};
 `;
+
+export const Section = styled.section`
+  padding: 40px 0;
+`;
+
+export const Ticker = styled.div`
+  overflow-x: auto;
+  white-space: nowrap;
+  background: ${COLORS.primary};
+  color: #fff;
+  padding: 8px 0;
+  font-size: 0.9rem;
+`;
+
+export const NewsGrid = styled.div`
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+`;
+
+export const NewsCard = styled.div`
+  width: 260px;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  img {
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+  }
+  div {
+    padding: 10px;
+  }
+`;
+
+export const Spinner = styled.div`
+  border: 4px solid ${COLORS.lightBg};
+  border-top: 4px solid ${COLORS.secondary};
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+export const ToggleButton = styled.button`
+  background: none;
+  border: 1px solid ${COLORS.secondary};
+  color: ${COLORS.text};
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## Summary
- add global Poppins font and dark mode styles
- introduce various styled components (Section, Ticker, NewsCard, etc.)
- enable dark mode toggle in Navbar/App
- redesign WorldCup page with sections, ticker, news cards and loader
- install `dayjs`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68608f141f948323839b990897edeed1